### PR TITLE
set minimun required of PHP to "^7.3|^8.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
       }
   ],
   "require": {
-      "php": ">7.0",
+      "php": "^7.3|^8.0",
       "laravel/framework": ">8.0"
   },
   "require-dev": {


### PR DESCRIPTION
On branch fix/update-dependency-version
Changes to be committed:
	modified:   composer.json


Esta alteração atualiza a versão mínima do PHP exigida pelo projeto de >7.0 para ^7.3|^8.0, a fim de aproveitar os recursos e melhorias mais recentes do PHP. Além disso, a versão do Laravel/Framework exigida pelo projeto foi atualizada para >8.0. Isso garantirá que o projeto esteja atualizado com as melhores práticas e os recursos mais recentes